### PR TITLE
Removed emojis that were shown on embed

### DIFF
--- a/src/commands/partner/bump.js
+++ b/src/commands/partner/bump.js
@@ -103,11 +103,11 @@ function bumpLogic (client, message, row, invite) {
                 value: `Online: \`${guildInfo.online}\` | Idle: \`${guildInfo.idle}\` | DnD: \`${guildInfo.dnd}\``,
                 inline: false
               },
-              {
-                name: `Emojis: \`${message.guild.emojis.cache.size}\``,
-                value: message.guild.emojis.cache.size === 0 ? 'No Emotes' : `${guildInfo.emojis.join(' ')}`,
-                inline: false
-              }
+              
+              
+
+
+
             ],
             thumbnail: {
               url: message.guild.iconURL()


### PR DESCRIPTION
I just deleted the {} field of emojis part inside embed, although I didn't remove the part where the bot searches for emojis, and the space where the emojis field in embed were written, I did this with GitHub Website and not a code editor, so I couldn't delete lines... 😅